### PR TITLE
fix: 댓글, 게시글, 공지사항 도메인 및 DTO 수정

### DIFF
--- a/src/main/java/com/est/cranejob/announcement/dto/request/CreateAnnouncementRequest.java
+++ b/src/main/java/com/est/cranejob/announcement/dto/request/CreateAnnouncementRequest.java
@@ -11,7 +11,10 @@ import java.io.Serializable;
  * 공지사항 생성을 요청하는 DTO<br>
  * DTO for {@link com.est.cranejob.announcement.domain.Announcement}
  */
-@Data
+@Getter
+@Setter
+@AllArgsConstructor
+@NoArgsConstructor
 @Builder
 public class CreateAnnouncementRequest implements Serializable{
 

--- a/src/main/java/com/est/cranejob/announcement/dto/request/UpdateAnnouncementRequest.java
+++ b/src/main/java/com/est/cranejob/announcement/dto/request/UpdateAnnouncementRequest.java
@@ -10,7 +10,10 @@ import java.io.Serializable;
 /**
  * DTO for {@link com.est.cranejob.announcement.domain.Announcement}
  */
-@Data
+@Getter
+@Setter
+@AllArgsConstructor
+@NoArgsConstructor
 @Builder
 public class UpdateAnnouncementRequest implements Serializable {
     @NotNull(message = "공지사항의 제목은 빈 값이 들어갈 수 없습니다.")

--- a/src/main/java/com/est/cranejob/announcement/dto/response/AnnouncementDetailResponse.java
+++ b/src/main/java/com/est/cranejob/announcement/dto/response/AnnouncementDetailResponse.java
@@ -1,7 +1,8 @@
 package com.est.cranejob.announcement.dto.response;
 
-import lombok.Builder;
-import lombok.Data;
+import com.est.cranejob.announcement.domain.Announcement;
+import lombok.*;
+
 import java.io.Serializable;
 import java.time.LocalDateTime;
 
@@ -10,14 +11,27 @@ import java.time.LocalDateTime;
  * DTO for {@link com.est.cranejob.announcement.domain.Announcement}
  */
 
-
-@Data
+@Getter
+@Setter
+@AllArgsConstructor
+@NoArgsConstructor
 @Builder
 public class AnnouncementDetailResponse implements Serializable {
     private Long id; // 공지사항 ID
     private String title; // 공지사항 제목
     private String content; // 공지사항 내용
-    private String userNickname; // 작성자 닉네임
+    private String nickname; // 작성자 닉네임
     private LocalDateTime createdAt; // 작성 시간
     private LocalDateTime updatedAt; // 수정 시간
+
+    public static AnnouncementDetailResponse toDTO(Announcement announcement){
+        return AnnouncementDetailResponse.builder()
+                .id(announcement.getId())
+                .title(announcement.getTitle())
+                .content(announcement.getContent())
+                .nickname(announcement.getUser().getNickname())
+                .createdAt(announcement.getCreatedAt())
+                .createdAt(announcement.getUpdatedAt())
+                .build();
+    }
 }

--- a/src/main/java/com/est/cranejob/announcement/dto/response/AnnouncementResponse.java
+++ b/src/main/java/com/est/cranejob/announcement/dto/response/AnnouncementResponse.java
@@ -1,5 +1,6 @@
 package com.est.cranejob.announcement.dto.response;
 
+import com.est.cranejob.announcement.domain.Announcement;
 import lombok.*;
 import lombok.experimental.Accessors;
 
@@ -10,10 +11,21 @@ import java.time.LocalDateTime;
  * 공지사항 요약을 나타내는 DTO<br>
  * DTO for {@link com.est.cranejob.announcement.domain.Announcement}
  */
-@Data
+@Getter
+@Setter
+@AllArgsConstructor
+@NoArgsConstructor
 @Builder
 public class AnnouncementResponse implements Serializable {
     private Long id; // 공지사항 id
     private String title; // 공지사항 제목
     private LocalDateTime createdAt; // 공지사항 생성일
+
+    public static AnnouncementResponse toDTO(Announcement announcement){
+        return AnnouncementResponse.builder()
+                .id(announcement.getId())
+                .title(announcement.getTitle())
+                .createdAt(announcement.getCreatedAt())
+                .build();
+    }
 }

--- a/src/main/java/com/est/cranejob/comment/dto/request/CreateCommentRequest.java
+++ b/src/main/java/com/est/cranejob/comment/dto/request/CreateCommentRequest.java
@@ -3,8 +3,7 @@ package com.est.cranejob.comment.dto.request;
 import com.est.cranejob.comment.domain.Comment;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
-import lombok.Builder;
-import lombok.Data;
+import lombok.*;
 
 import java.io.Serializable;
 
@@ -13,7 +12,10 @@ import java.io.Serializable;
  * DTO for {@link com.est.cranejob.comment.domain.Comment}
  */
 
-@Data
+@Getter
+@Setter
+@AllArgsConstructor
+@NoArgsConstructor
 @Builder
 public class CreateCommentRequest implements Serializable {
 

--- a/src/main/java/com/est/cranejob/comment/dto/request/UpdateCommentRequest.java
+++ b/src/main/java/com/est/cranejob/comment/dto/request/UpdateCommentRequest.java
@@ -2,8 +2,7 @@ package com.est.cranejob.comment.dto.request;
 
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
-import lombok.Builder;
-import lombok.Data;
+import lombok.*;
 
 import java.io.Serializable;
 
@@ -11,7 +10,10 @@ import java.io.Serializable;
  * 댓글 수정 요청을 보내는 DTO<br>
  * DTO for {@link com.est.cranejob.comment.domain.Comment}
  */
-@Data
+@Getter
+@Setter
+@AllArgsConstructor
+@NoArgsConstructor
 @Builder
 public class UpdateCommentRequest implements Serializable {
 

--- a/src/main/java/com/est/cranejob/comment/dto/response/CommentDetailResponse.java
+++ b/src/main/java/com/est/cranejob/comment/dto/response/CommentDetailResponse.java
@@ -1,5 +1,6 @@
 package com.est.cranejob.comment.dto.response;
 
+import com.est.cranejob.comment.domain.Comment;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.PastOrPresent;
@@ -24,7 +25,21 @@ public class CommentDetailResponse implements Serializable {
     private LocalDateTime updatedAt;
     private Boolean isDeleted;
     private LocalDateTime deletedAt;
-    private Long userId;
-    private String userNickname;
-    private Long postId;
+    private Long user;
+    private String nickname;
+    private Long post;
+
+    public static CommentDetailResponse toDTO(Comment comment) {
+        return CommentDetailResponse.builder()
+                .id(comment.getId())
+                .content(comment.getContent())
+                .createdAt(comment.getCreatedAt())
+                .updatedAt(comment.getUpdatedAt())
+                .isDeleted(comment.getIsDeleted())
+                .deletedAt(comment.getDeletedAt())
+                .user(comment.getUser().getId())
+                .nickname(comment.getUser().getNickname())
+                .post(comment.getPost().getId())
+                .build();
+    }
 }

--- a/src/main/java/com/est/cranejob/comment/dto/response/CommentResponse.java
+++ b/src/main/java/com/est/cranejob/comment/dto/response/CommentResponse.java
@@ -1,5 +1,6 @@
 package com.est.cranejob.comment.dto.response;
 
+import com.est.cranejob.comment.domain.Comment;
 import lombok.Builder;
 import lombok.Data;
 
@@ -16,5 +17,13 @@ public class CommentResponse implements Serializable {
 
     private String content; // 댓글 내용
     private LocalDateTime createdAt; // 댓글 작성일
-    private String userNickname;
+    private String nickname;
+
+    public static CommentResponse toDTO(Comment comment) {
+        return CommentResponse.builder()
+                .content(comment.getContent())
+                .createdAt(comment.getCreatedAt())
+                .nickname(comment.getUser().getNickname())
+                .build();
+    }
 }

--- a/src/main/java/com/est/cranejob/post/domain/Post.java
+++ b/src/main/java/com/est/cranejob/post/domain/Post.java
@@ -50,6 +50,12 @@ public class Post extends BaseEntity {
 		comment.setPost(this);
 	}
 
+	// 게시글 업데이트
+	public void updatePost(String title, String content) {
+		this.title = title;
+		this.content = content;
+	}
+
 	public void setUser(User user) {
 		this.user = user;
 	}

--- a/src/main/java/com/est/cranejob/post/dto/request/CreatePostRequest.java
+++ b/src/main/java/com/est/cranejob/post/dto/request/CreatePostRequest.java
@@ -3,8 +3,7 @@ package com.est.cranejob.post.dto.request;
 import com.est.cranejob.post.domain.Post;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
-import lombok.Builder;
-import lombok.Data;
+import lombok.*;
 
 import java.io.Serializable;
 
@@ -13,7 +12,10 @@ import java.io.Serializable;
  * DTO for {@link com.est.cranejob.post.domain.Post}
  */
 
-@Data
+@Getter
+@Setter
+@AllArgsConstructor
+@NoArgsConstructor
 @Builder
 public class CreatePostRequest implements Serializable {
 

--- a/src/main/java/com/est/cranejob/post/dto/request/UpdatePostRequest.java
+++ b/src/main/java/com/est/cranejob/post/dto/request/UpdatePostRequest.java
@@ -2,8 +2,7 @@ package com.est.cranejob.post.dto.request;
 
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
-import lombok.Builder;
-import lombok.Data;
+import lombok.*;
 
 import java.io.Serializable;
 
@@ -11,7 +10,10 @@ import java.io.Serializable;
  * 게시글 수정 요청을 보내는 DTO<br>
  * DTO for {@link com.est.cranejob.post.domain.Post}
  */
-@Data
+@Getter
+@Setter
+@AllArgsConstructor
+@NoArgsConstructor
 @Builder
 public class UpdatePostRequest implements Serializable {
     @NotNull(message = "제목을 입력해 주세요.")

--- a/src/main/java/com/est/cranejob/post/dto/response/PostAdminDetailResponse.java
+++ b/src/main/java/com/est/cranejob/post/dto/response/PostAdminDetailResponse.java
@@ -1,9 +1,9 @@
 package com.est.cranejob.post.dto.response;
 
 import com.est.cranejob.comment.dto.response.CommentDetailResponse;
+import com.est.cranejob.post.domain.Post;
 import com.est.cranejob.user.domain.User;
-import lombok.Builder;
-import lombok.Data;
+import lombok.*;
 
 import java.io.Serializable;
 import java.time.LocalDateTime;
@@ -13,7 +13,10 @@ import java.util.List;
  * 게시물 상세 정보를 관리자가 볼 수 있는 형태로 응답하는 DTO<br>
  * DTO for {@link com.est.cranejob.post.domain.Post}
  */
-@Data
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
 @Builder
 public class PostAdminDetailResponse implements Serializable {
     private Long id; // 게시글 id
@@ -21,8 +24,23 @@ public class PostAdminDetailResponse implements Serializable {
     private String content; // 게시글 내용
     private LocalDateTime createdAt; // 게시글 생성 일시
     private LocalDateTime updatedAt; // 게시글 마지막 수정 일시
-    boolean isDeleted; // 삭제 여부
+    private boolean isDeleted; // 삭제 여부
     private LocalDateTime deletedAt; // 삭제 일시
-    private User userNickname; // 작성자 이름
+    private String nickname; // 작성자 이름
     private List<CommentDetailResponse> commentDetailResponses; // 관리자가 볼 수 있는 댓글 생세
+
+    public static PostAdminDetailResponse toDTO(Post post){
+        List<CommentDetailResponse> commentDetailResponseList = post.getComments().stream().map(CommentDetailResponse::toDTO).toList();
+        return PostAdminDetailResponse.builder()
+                .id(post.getId())
+                .title(post.getTitle())
+                .content(post.getContent())
+                .createdAt(post.getCreatedAt())
+                .updatedAt(post.getUpdatedAt())
+                .isDeleted(post.isDeleted())
+                .deletedAt(post.getDeletedAt())
+                .nickname(post.getUser().getNickname())
+                .commentDetailResponses(commentDetailResponseList)
+                .build();
+    }
 }

--- a/src/main/java/com/est/cranejob/post/dto/response/PostSummaryResponse.java
+++ b/src/main/java/com/est/cranejob/post/dto/response/PostSummaryResponse.java
@@ -1,10 +1,9 @@
 package com.est.cranejob.post.dto.response;
 
+import com.est.cranejob.post.domain.Post;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
-import lombok.Builder;
-import lombok.Data;
-import lombok.Value;
+import lombok.*;
 
 import java.io.Serializable;
 import java.time.LocalDateTime;
@@ -13,11 +12,23 @@ import java.time.LocalDateTime;
  * 게시글을 요약한 상태로 수 있는 형태로 응답하는 DTO<br>
  * DTo for {@link com.est.cranejob.post.domain.Post}
  */
-@Data
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
 @Builder
 public class PostSummaryResponse implements Serializable {
     private Long id; // 게시글 id
     private String title; // 게시글 제목
     private LocalDateTime createdAt; // 게시글 생성 일시
-    private String userNickname; // 게시글 작성자
+    private String nickname; // 게시글 작성자
+
+    public static PostSummaryResponse toDTO(Post post){
+        return PostSummaryResponse.builder()
+                .id(post.getId())
+                .title(post.getTitle())
+                .createdAt(post.getCreatedAt())
+                .nickname(post.getUser().getNickname())
+                .build();
+    }
 }

--- a/src/main/java/com/est/cranejob/post/dto/response/PostUserDetailResponse.java
+++ b/src/main/java/com/est/cranejob/post/dto/response/PostUserDetailResponse.java
@@ -1,8 +1,8 @@
 package com.est.cranejob.post.dto.response;
 
 import com.est.cranejob.comment.dto.response.CommentResponse;
-import lombok.Builder;
-import lombok.Data;
+import com.est.cranejob.post.domain.Post;
+import lombok.*;
 
 import java.io.Serializable;
 import java.util.List;
@@ -11,12 +11,28 @@ import java.util.List;
  * 게시글의 상세 정보를 일반 사용자가 볼 수 있는 형태로 응답하는 DTO<br>
  * DTO for {@link com.est.cranejob.post.domain.Post}
  */
-@Data
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
 @Builder
 public class PostUserDetailResponse implements Serializable {
     private Long id; // 게시글 id
     private String title; // 게시글 제목
     private String content; // 게시글 내용
     private List<CommentResponse> commentResponses; // 게시글에 작성된 댓글
-    private String userNickname; // 게시글 작성자
+    private String nickname; // 게시글 작성자
+
+    public static PostUserDetailResponse toDTO(Post post){
+        List<CommentResponse> commentResponseList = post.getComments().stream().map(CommentResponse::toDTO)
+                .toList();
+        return PostUserDetailResponse.builder()
+                .id(post.getId())
+                .title(post.getTitle())
+                .content(post.getContent())
+                .commentResponses(commentResponseList)
+                .nickname(post.getUser().getNickname())
+                .build();
+    }
+
 }

--- a/src/main/java/com/est/cranejob/post/repository/PostRepository.java
+++ b/src/main/java/com/est/cranejob/post/repository/PostRepository.java
@@ -1,8 +1,10 @@
 package com.est.cranejob.post.repository;
 
+import com.est.cranejob.post.domain.Post;
+import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 @Repository
-public interface PostRepository {
+public interface PostRepository extends JpaRepository<Post, Long> {
 
 }


### PR DESCRIPTION
- 게시글 도메인에 updatePost메서드를 추가했습니다.
- 댓글, 게시글, 공지사항 DTO에 롬복 수정 및 toDTO 생성 했습니다.
- UserPostController(사용자 게시판 CRUD) 및 UserPostService 클래스는 작성은 했는데 게시글을 생성하면 생성은 안되고 로그인 페이지로 자꾸 넘어가는 문제가 있어서 좀 더 알아보고 말씀 드리겠습니다.