### PR TITLE
게시글 수정 로직, 게시글 관련 HTML 추가 및 변경, 시큐리티 수정(페이지 접근 권한)

### DIFF
--- a/src/main/java/com/est/cranejob/post/dto/response/PostUserDetailResponse.java
+++ b/src/main/java/com/est/cranejob/post/dto/response/PostUserDetailResponse.java
@@ -22,6 +22,7 @@ public class PostUserDetailResponse implements Serializable {
     private String content; // 게시글 내용
     private List<CommentResponse> commentResponses; // 게시글에 작성된 댓글
     private String nickname; // 게시글 작성자
+    private String username; // 게시글 작성자 확인
 
     public static PostUserDetailResponse toDTO(Post post){
         List<CommentResponse> commentResponseList = post.getComments().stream().map(CommentResponse::toDTO)
@@ -32,6 +33,7 @@ public class PostUserDetailResponse implements Serializable {
                 .content(post.getContent())
                 .commentResponses(commentResponseList)
                 .nickname(post.getUser().getNickname())
+                .username(post.getUser().getUsername())
                 .build();
     }
 

--- a/src/main/java/com/est/cranejob/post/service/PostService.java
+++ b/src/main/java/com/est/cranejob/post/service/PostService.java
@@ -4,7 +4,9 @@ import com.est.cranejob.announcement.domain.Announcement;
 import com.est.cranejob.announcement.repository.AnnouncementRepository;
 import com.est.cranejob.post.domain.Post;
 import com.est.cranejob.post.dto.request.CreatePostRequest;
+import com.est.cranejob.post.dto.request.UpdatePostRequest;
 import com.est.cranejob.post.dto.response.PostSummaryResponse;
+import com.est.cranejob.post.dto.response.PostUserDetailResponse;
 import com.est.cranejob.post.repository.PostRepository;
 import com.est.cranejob.user.domain.User;
 import java.util.ArrayList;
@@ -50,7 +52,6 @@ public class PostService {
                 .toList();
     }
 
-    /*// 사용자용 게시글 상세 정보를 조회하여 PostUserDetailResponse로 반환
     @Transactional(readOnly = true)
     public PostUserDetailResponse findPostById(Long id){
         log.debug("Update post details for ID: {}", id);
@@ -68,7 +69,7 @@ public class PostService {
         post.updatePost(updatePostRequest.getTitle(), updatePostRequest.getContent());
         postRepository.save(post);
         log.debug("Post updated and saved successfully.");
-    }*/
+    }
 
     public Page<PostSummaryResponse> getPaginatedPosts(Pageable pageable, String keyword) {
         // 페이지네이션 기본 정보 설정

--- a/src/main/java/com/est/cranejob/security/config/SecurityConfig.java
+++ b/src/main/java/com/est/cranejob/security/config/SecurityConfig.java
@@ -23,7 +23,7 @@ public class SecurityConfig {
 			.securityMatcher("/", "/user/**", "/user/login", "/user/signup", "/post/**")
 			.authorizeHttpRequests(authorize -> authorize
 				.requestMatchers("/css/**", "/images/**", "/js/**", "/favicon.*", "/*/icon-*").permitAll()
-				.requestMatchers("/", "/user/login", "/user/signup", "/post/list").permitAll()
+				.requestMatchers("/", "/user/login", "/user/signup", "/post/list","/post/detail/**").permitAll()
 				.requestMatchers("/user/**").hasAnyRole("USER", "ADMIN")
 				.anyRequest().authenticated()
 			)

--- a/src/main/resources/templates/post/edit.html
+++ b/src/main/resources/templates/post/edit.html
@@ -1,0 +1,37 @@
+<!DOCTYPE html>
+<html lang="en" xmlns:th="http://www.thymeleaf.org" xmlns:sec="http://www.thymeleaf.org/thymeleaf-extras-springsecurity6">
+<head>
+    <meta charset="UTF-8">
+    <link href="../css/bootstrap.min.css" th:href="@{/css/bootstrap.min.css}" rel="stylesheet">
+</head>
+<style>
+    .layout {
+        width: 1000px;
+        margin: 0 auto;
+        margin-top: 40px;
+    }
+</style>
+<body>
+<!-- 게시글 수정 폼-->
+<div class="layout">
+    <h1>게시글 수정</h1>
+    <form th:action="@{/post/edit/{id}(id=${postUserDetailResponse.id})}" method="post">
+        <!-- 이 숨겨진 필드를 추가하여 메서드를 PUT으로 설정 -->
+        <input type="hidden" name="_method" value="put"/>
+        <div>
+            <label for="title">제목</label>
+            <input type="text" id="title" th:field="*{updatePostRequest.title}" class="form-control"/>
+        </div>
+        <div>
+            <label for="content">내용</label>
+            <textarea id="content" th:field="*{updatePostRequest.content}" class="form-control" rows="10"></textarea>
+        </div>
+        <div style="margin-top: 20px;">
+            <button type="submit" class="btn btn-primary">저장</button>
+            <a href="/post/list" class="btn btn-secondary">취소</a>
+        </div>
+    </form>
+</div>
+
+</body>
+</html>

--- a/src/main/resources/templates/post/list.html
+++ b/src/main/resources/templates/post/list.html
@@ -96,8 +96,8 @@
 		</thead>
 		<tbody align="center">
 		<tr th:each="post : ${postSummaryResponseList}">
-			<td class="text-start"><a th:href="@{/post/{id}(id=${post.id})}" th:text="${post.id}">게시글 제목</a></td>
-			<td class="text-start"><a th:href="@{/post/{id}(id=${post.id})}" th:text="${post.title}">게시글 제목</a></td>
+			<td class="text-start"><a th:href="@{/post/detail/{id}(id=${post.id})}" th:text="${post.id}">게시글 제목</a></td>
+			<td class="text-start"><a th:href="@{/post/detail/{id}(id=${post.id})}" th:text="${post.title}">게시글 제목</a></td>
 			<td class="text-start" th:text="${post.nickname}">작성자</td>
 			<td class="text-start" th:text="${post.createdAt}">작성일</td>
 		</tr>

--- a/src/main/resources/templates/post/userDetail.html
+++ b/src/main/resources/templates/post/userDetail.html
@@ -1,0 +1,42 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org">
+<head>
+    <meta charset="UTF-8">
+    <title>게시글 상세</title>
+    <style>
+    </style>
+</head>
+<body>
+<h1>게시글 상세</h1>
+<table>
+    <tr>
+        <th>제목</th>
+        <td th:text="${postUserDetailResponse.title}"></td>
+    </tr>
+    <tr>
+        <th>내용</th>
+        <td th:text="${postUserDetailResponse.content}"></td>
+    </tr>
+    <tr>
+        <th>작성자</th>
+        <td th:text="${postUserDetailResponse.getNickname()}"></td>
+    </tr>
+    <!--<tr>
+        <th>작성일</th>
+        <td th:text="${#dates.format(postUserDetailResponse.createdAt, 'yyyy-MM-dd HH:mm:ss')}"></td>
+    </tr>
+    <tr>
+        <th>수정일</th>
+        <td th:text="${#dates.format(postUserDetailResponse.updatedAt, 'yyyy-MM-dd HH:mm:ss')}"></td>
+    </tr>-->
+</table>
+
+<div class="action-buttons">
+    <a href="#" th:href="@{/post/edit/{id}(id=${postUserDetailResponse.id})}">수정하기</a>
+    <form th:action="@{/post/delete/{id}(id=${postUserDetailResponse.id})}" method="post">
+        <button type="submit">삭제하기</button>
+    </form>
+    <a href="/post/list">목록으로 돌아가기</a>
+</div>
+</body>
+</html>


### PR DESCRIPTION
- 게시글 수정 로직 작성했습니다.
  - 게시글의 작성자만 수정 페이지로 넘어갑니다.
  - 게시글의 작성자가 아닌 사용자는 수정하기 버튼을 누르면 초기화면인 **"post/list"** 페이지로 리다이렉트 합니다.
  - 게시글 수정 처리를 Put 메서드로 하도록 변경했습니다.
  - 게시글 상세 페이지의 URL을 **"post/{id}"** 에서 **"post/detail/{id}"** 로 변경했습니다.
-  게시글 상세, 게시글 수정 페이지 작성 및 초기 리스트 페이지에서 제목 타고 넘어가는 링크를 **"post/detail/{id}"** 로 변경했습니다.
  - 게시글 상세
    <img width="500" alt="스크린샷 2024-07-30 오후 10 56 20" src="https://github.com/user-attachments/assets/5db68e8a-607d-448d-bfed-78261c27609e">
  - 게시글 상세 URL
    <img width="261" alt="스크린샷 2024-07-30 오후 10 56 34" src="https://github.com/user-attachments/assets/def11a73-468c-436b-8143-36cc423bf5d9">
  - 게시글 수정
    <img width="814" alt="스크린샷 2024-07-30 오후 10 56 52" src="https://github.com/user-attachments/assets/205d6101-e535-4cb5-9f70-f4fc4a84ea7e">
- **SecurityConfig** 에서 로그인 없이 접근 가능한 페이지에 게시글 상세 페이지를 추가했습니다.