### PR TITLE
feat: 삭제 로직 추가

### DIFF
--- a/src/main/java/com/est/cranejob/post/domain/Post.java
+++ b/src/main/java/com/est/cranejob/post/domain/Post.java
@@ -55,6 +55,10 @@ public class Post extends BaseEntity {
 		this.title = title;
 		this.content = content;
 	}
+	public void deletedPost(){
+		this.isDeleted = true;
+		this.deletedAt = LocalDateTime.now();
+	}
 
 	public void setUser(User user) {
 		this.user = user;

--- a/src/main/java/com/est/cranejob/post/repository/PostRepository.java
+++ b/src/main/java/com/est/cranejob/post/repository/PostRepository.java
@@ -9,7 +9,7 @@ import org.springframework.stereotype.Repository;
 @Repository
 public interface PostRepository extends JpaRepository<Post, Long> {
 
-	@Query("select p from Post p where p.title like %?1% or p.user.nickname like %?1%")
+	@Query("select p from Post p where (p.title like %?1% or p.user.nickname like %?1%) and p.isDeleted = false")
 	List<Post> findPostByKeyword(String keyword);
 
 }

--- a/src/main/resources/templates/post/userDetail.html
+++ b/src/main/resources/templates/post/userDetail.html
@@ -34,8 +34,8 @@
 
 <div class="action-buttons">
     <a href="#" th:href="@{/post/edit/{id}(id=${postUserDetailResponse.id})}">수정하기</a>
-    <form th:action="@{/post/delete/{id}(id=${postUserDetailResponse.id})}" method="post">
-        <button type="submit">삭제하기</button>
+    <form th:action="@{/post/delete/{id}(id=${postUserDetailResponse.id})}" method="post" style="display: inline;">
+        <button type="submit" onclick="return confirm('정말로 삭제하시겠습니까?');">삭제하기</button>
     </form>
     <a href="/post/list">목록으로 돌아가기</a>
 </div>


### PR DESCRIPTION
- 게시글 삭제 로직 추가
- 게시글 작성자가 아닌 유저가 삭제를 하면 listPage로 이동
(어제 작성한 로직으로 좀전에 해봤는데 list 페이지로 안가고 다른 URL로 넘어가져서 해당 부분 수정 후 올렸습니다.)
- 로그인 되지않은 사용자가 삭제 버튼을 누르면 loginPage로 이동
- 삭제 버튼 클릭시 alert창에서 한번 더 확인