### PR TITLE
fix: 댓글 수정 및 삭제시 400에러 해결

### DIFF
--- a/src/main/java/com/est/cranejob/comment/controller/CommentController.java
+++ b/src/main/java/com/est/cranejob/comment/controller/CommentController.java
@@ -19,6 +19,7 @@ import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
@@ -75,10 +76,22 @@ public class CommentController {
 
     @PutMapping("/comment/{commentId}")
     public ResponseEntity<CommentResponse> updateComment(@PathVariable("commentId") Long commentId,
-                                                         @Valid @RequestBody UpdateCommentRequest updateRequest) {
+                                                         @Valid @RequestBody UpdateCommentRequest updateRequest,
+                                                         Model model) {
         // 현재 로그인한 사용자 확인
         Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
-        if (authentication == null || !authentication.isAuthenticated() || !(authentication.getPrincipal() instanceof UserDetails)) {
+        if (authentication == null) {
+            log.warn("Authentication object is null");
+            return ResponseEntity.status(HttpStatus.UNAUTHORIZED).build();
+        }
+
+        if (!authentication.isAuthenticated()) {
+            log.warn("User is not authenticated");
+            return ResponseEntity.status(HttpStatus.UNAUTHORIZED).build();
+        }
+
+        if (authentication.getPrincipal() == null) {
+            log.warn("Principal is not an instance of UserDetails");
             return ResponseEntity.status(HttpStatus.UNAUTHORIZED).build();
         }
 
@@ -91,6 +104,8 @@ public class CommentController {
             return ResponseEntity.status(HttpStatus.FORBIDDEN).build(); // 수정 권한이 없는 경우
         }
 
+//        model.addAttribute("");
+
         comment.updateComment(updateRequest.getContent());
         Comment updatedComment = commentService.updateComment(commentId, comment);
         return ResponseEntity.ok(CommentResponse.toDTO(updatedComment));
@@ -101,7 +116,18 @@ public class CommentController {
     public ResponseEntity<Void> deleteComment(@PathVariable("commentId") Long commentId) {
         // 현재 로그인한 사용자 확인
         Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
-        if (authentication == null || !authentication.isAuthenticated() || !(authentication.getPrincipal() instanceof UserDetails)) {
+        if (authentication == null) {
+            log.warn("Authentication object is null");
+            return ResponseEntity.status(HttpStatus.UNAUTHORIZED).build();
+        }
+
+        if (!authentication.isAuthenticated()) {
+            log.warn("User is not authenticated");
+            return ResponseEntity.status(HttpStatus.UNAUTHORIZED).build();
+        }
+
+        if (authentication.getPrincipal() == null) {
+            log.warn("Principal is not an instance of UserDetails");
             return ResponseEntity.status(HttpStatus.UNAUTHORIZED).build();
         }
 

--- a/src/main/java/com/est/cranejob/comment/dto/response/CommentResponse.java
+++ b/src/main/java/com/est/cranejob/comment/dto/response/CommentResponse.java
@@ -17,12 +17,14 @@ import java.time.LocalDateTime;
 @Builder
 public class CommentResponse implements Serializable {
 
+    private Long id;
     private String content; // 댓글 내용
     private LocalDateTime createdAt; // 댓글 작성일
     private String nickname;
 
     public static CommentResponse toDTO(Comment comment) {
         return CommentResponse.builder()
+                .id(comment.getId())
                 .content(comment.getContent())
                 .createdAt(comment.getCreatedAt())
                 .nickname(comment.getUser().getNickname())


### PR DESCRIPTION
- 댓글 수정 및 삭제시 아래와 같이 commentId를 불러오지 못하여 400 에러가 나는 현상 해결
  - CommentResponse에서 id를 반환하도록 변경
  - 에러 메세지
  ![image](https://github.com/user-attachments/assets/ecfc70cf-a730-47f3-a1e2-15998444a551)
- 해결 후 DB(isDelete를 true로 변경하며 삭제 되는것을 확인할 수 있음)
  <img width="1021" alt="image" src="https://github.com/user-attachments/assets/ce2e00ab-f9b2-4e7f-abdb-731c1b8ecdda">

