### PR TITLE
feat: 게시글 상세, 게시글 작성 페이지 벨류데이션 태그 및 css 작성, 게시글 요청 어노테이션 수정

### DIFF
--- a/src/main/java/com/est/cranejob/post/dto/request/CreatePostRequest.java
+++ b/src/main/java/com/est/cranejob/post/dto/request/CreatePostRequest.java
@@ -1,6 +1,7 @@
 package com.est.cranejob.post.dto.request;
 
 import com.est.cranejob.post.domain.Post;
+import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
 import lombok.*;
@@ -19,11 +20,11 @@ import java.io.Serializable;
 @Builder
 public class CreatePostRequest implements Serializable {
 
-    @NotNull(message = "제목을 작성해 주세요.")
+    @NotBlank(message = "제목을 작성해 주세요.")
     @Size(max = 50, message = "제목은 50자 내로 작성해 주세요.")
     private String title;
 
-    @NotNull(message = "내용을 작성해 주세요.")
+    @NotBlank(message = "내용을 작성해 주세요.")
     private String content;
 
     // private User user; userId는 서비스 계층에서 관리

--- a/src/main/resources/templates/post/form.html
+++ b/src/main/resources/templates/post/form.html
@@ -37,6 +37,10 @@
     .back-to-list:hover {
         background-color: #0c4ea9;
     }
+    .field-error {
+        border-color: #dc3545;
+        color: #dc3545;
+    }
 </style>
 <body>
 <div th:replace="~{/layout/header.html :: header}"></div>
@@ -46,11 +50,17 @@
 <form th:action="@{/post/form}" th:object="${createPostRequest}" th:method="post">
     <div>
         <label for="title">제목</label>
-        <input type="text" id="title" th:field="*{title}" class="form-control" style="margin: 20px 0;"/>
+        <input type="text" id="title" th:field="*{title}" th:errorclass="field-error" class="form-control" style="margin: 20px 0;" placeholder="제목을 입력해 주세요."/>
+        <div class="field-error" th:errors="*{title}">
+            제목 오류
+        </div>
     </div>
     <div>
         <label for="content">내용</label>
-        <textarea id="content" th:field="*{content}" class="form-control" style="margin: 20px 0; height: 400px;" ></textarea>
+        <textarea id="content" th:field="*{content}" th:errorclass="field-error" class="form-control" style="margin: 20px 0; height: 400px;" placeholder="내용을 입력해 주세요."></textarea>
+        <div class="field-error" th:errors="*{content}">
+            내용 오류
+        </div>
     </div>
     <button type="submit">저장</button>
 </form>

--- a/src/main/resources/templates/post/postDetail.html
+++ b/src/main/resources/templates/post/postDetail.html
@@ -77,6 +77,115 @@
         th {
             width: 10%;
         }
+
+        /*댓글 form ~ 댓글 리스트*/
+        #comment-section {
+            margin: 20px 24%;
+        }
+
+        /*댓글 작성폼*/
+        #comment-form {
+            display: flex;
+            align-items: flex-start;
+            margin-top: 20px;
+        }
+
+        #comment-form .comment-group {
+            flex: 1;
+            display: flex;
+            flex-direction: column;
+        }
+
+        #comment-form label {
+            font-weight: bold;
+            margin-bottom: 5px;
+        }
+
+        #comment-form textarea {
+            width: 100%;
+            height: 100px;
+            padding: 10px;
+            font-size: 14px;
+            border: 1px solid #ddd;
+            border-radius: 5px;
+            resize: none;
+        }
+
+        #comment-form textarea:focus {
+            outline: none;
+            border-color: #1665d4;
+            box-shadow: 0 0 5px rgba(22, 101, 212, 0.5);
+        }
+
+        /*댓글 작성폼 벨류데이션 에러*/
+        #comment-form .error-message {
+            color: red;
+            margin-top: 5px;
+            display: none;
+        }
+
+        /*댓글 생성 버튼*/
+        #create-comment-button {
+            margin-left: 10px;
+            padding: 10px 20px;
+            background-color: #1665d4;
+            color: white;
+            border: none;
+            border-radius: 5px;
+            font-size: 14px;
+            cursor: pointer;
+        }
+
+        #create-comment-button:hover {
+            background-color: #0c4ea9;
+        }
+
+        /*댓글 리스트*/
+        .comment-container {
+            margin-top: 20px;
+        }
+
+        .comment-table {
+            width: 100%;
+            border-collapse: collapse;
+        }
+
+        .comment-table th, .comment-table td {
+            border: 1px solid #ddd;
+            padding: 8px;
+            text-align: left;
+        }
+
+        .comment-actions {
+            display: flex;
+            gap: 10px;
+        }
+
+        .comment-actions button {
+            padding: 5px 10px;
+            border: none;
+            border-radius: 5px;
+            cursor: pointer;
+        }
+
+        /*댓글 삭제 및 수정 버튼*/
+        .comment-actions .edit-comment-btn {
+            background-color: #ffc444;
+            color: #ffffff;
+        }
+
+        .comment-actions .edit-comment-btn:hover {
+            background-color: #ffc000;
+        }
+
+        .comment-actions .delete-comment-btn {
+            background-color: #ff4444;
+            color: #ffffff;
+        }
+
+        .comment-actions .delete-comment-btn:hover {
+            background-color: #ff0000;
+        }
     </style>
 </head>
 <body>
@@ -109,6 +218,14 @@
 </div>
 
 <section id="comment-section">
+    <form id="comment-form">
+        <div class="comment-group">
+            <label for="comment">댓글 추가</label>
+            <textarea class="form-content" id="comment" cols="30" rows="10" placeholder="댓글을 작성해 주세요"></textarea>
+            <div id="comment-error" class="error-message" style="color: red; display: none;"></div>
+        </div>
+        <button type="button" class="btn btn-primary" id="create-comment-button">댓글 작성</button>
+    </form>
     <div class="comment-container">
         <table class="comment-table">
             <thead>
@@ -124,13 +241,6 @@
             </tbody>
         </table>
     </div>
-    <form id="comment-form">
-        <div class="comment-group">
-            <label for="comment">댓글 추가</label>
-            <textarea class="form-content" id="comment" cols="30" rows="10"></textarea>
-        </div>
-        <button type="button" class="btn btn-primary" id="create-comment-button">댓글 작성</button>
-    </form>
 </section>
 
 <script>
@@ -149,12 +259,28 @@
         // 댓글 추가 함수
         async function addComment(postId) {
             const commentContent = document.getElementById('comment').value;
+            const errorDiv = document.getElementById('comment-error');
+
+            // 유효성 검사
+            /*if (!commentContent){
+                alert('댓글을 작성해 주세요');
+            } else if (commentContent.length > 10){
+                alert('댓글은 10자 이내로 작성해 주새요.')
+            }*/
 
             if (!commentContent) {
-                alert('댓글을 입력해주세요.');
+                errorDiv.textContent = '댓글을 입력해주세요.';
+                errorDiv.style.display = 'block';
+                document.getElementById('comment').style.borderColor = 'red';
                 return;
+            } else if (commentContent.length > 10) {
+                errorDiv.textContent = '10자 이내로 작성해 주세요';
+                errorDiv.style.display = 'block';
+                document.getElementById('comment').style.borderColor = 'red';
+            } else {
+                errorDiv.style.display = 'none';
+                errorDiv.style.borderColor = 'red';
             }
-
             try {
                 const response = await fetch(`/api/comment/${postId}`, {
                     method: 'POST',
@@ -162,7 +288,7 @@
                         'Content-Type': 'application/json',
                         [csrfHeader]: csrfToken
                     },
-                    body: JSON.stringify({ content: commentContent })
+                    body: JSON.stringify({content: commentContent})
                 });
 
                 if (response.ok) {
@@ -243,9 +369,14 @@
         // 댓글 수정 함수
         async function editComment(commentId, currentContent) {
             const newContent = prompt('수정할 댓글 내용을 입력하세요:', currentContent);
+
+            // 댓글 수정 유효성 검사
             if (newContent === null || newContent.trim() === '') {
                 alert('내용을 입력해야 합니다.');
                 return;
+            }
+            if (newContent.length > 100) {
+                alert('100자 이내로 작성해 주세요')
             }
 
             try {
@@ -255,11 +386,14 @@
                         'Content-Type': 'application/json',
                         [csrfHeader]: csrfToken
                     },
-                    body: JSON.stringify({ content: newContent })
+                    body: JSON.stringify({content: newContent})
                 });
 
                 if (response.ok) {
                     loadComments(postId); // 댓글 목록 새로고침
+                } else if (response.status === 403) {
+                    alert('수정 권한이 없습니다.');
+                    console.error('댓글 수정 실패: 수정 권한이 없습니다.');
                 } else {
                     console.error('댓글 수정 실패');
                 }
@@ -283,6 +417,7 @@
                     console.log('댓글 삭제 성공');
                     loadComments(postId); // 댓글 목록 새로고침
                 } else if (response.status === 403) {
+                    alert('삭제 권한이 없습니다.');
                     console.error('댓글 삭제 실패: 권한이 없습니다.');
                 } else {
                     console.error('댓글 삭제 실패');


### PR DESCRIPTION
- 게시글 상세 페이지 벨류데이션 태그 및 css 작성 (<script> </script>에서 작성 했습니다.)
  - 댓글 작성시 100자 이상 작성하거나 빈값이 들어갈 경우 댓글창 아래에 메세지 출력 합니다.
  - 댓글 수정 및 삭제시 댓글 작성자가 아닌경우 alert창에 "수정(삭제) 권한이 없습니다." 출력 합니다.
  - 게시글 상세 페이지
    <img width="1470" alt="image" src="https://github.com/user-attachments/assets/8061b7e4-a2e9-4f00-a9ea-032cc690c0ca">

- 게시글 생성 페이지 벨류데이션 태그 작성
  - 게시글 작성시 제목 50자 이내로 작성
  - 제목과 내용 모두 빈값이 들어가면 안됩니다.
- CreatePostRequest 클래스의 어노테이션을 수정 했습니다
  - NotNull -> NotBlank