### PR TITLE
feat: content 컬럼 타입 text 타입으로 변경

### DIFF
--- a/src/main/java/com/est/cranejob/announcement/domain/Announcement.java
+++ b/src/main/java/com/est/cranejob/announcement/domain/Announcement.java
@@ -26,8 +26,7 @@ public class Announcement extends BaseEntity {
 	@Column(name = "title")
 	private String title;
 
-	@Lob
-	@Column(name = "content")
+	@Column(name = "content", columnDefinition = "text")
 	private String content;
 
 	@ManyToOne(fetch = FetchType.LAZY)

--- a/src/main/java/com/est/cranejob/post/domain/Post.java
+++ b/src/main/java/com/est/cranejob/post/domain/Post.java
@@ -28,7 +28,7 @@ public class Post extends BaseEntity {
 	@Column(name = "title")
 	private String title;
 
-	@Column(name = "content")
+	@Column(name = "content", columnDefinition = "text")
 	private String content;
 
 	@ManyToOne(fetch = FetchType.LAZY)


### PR DESCRIPTION
게시글의 content 컬럼과 공지사항의 content 컬럼이 각각 varchar(255), tinytext 타입으로 되어있어서 모두 text 타입으로 변경했습니다.