### PR TITLE
fix: 회원 탈퇴한 사용자의 게시글이 함께 삭제되지 않는 문제 해결

### DIFF
--- a/src/main/java/com/est/cranejob/post/repository/PostRepository.java
+++ b/src/main/java/com/est/cranejob/post/repository/PostRepository.java
@@ -2,6 +2,8 @@ package com.est.cranejob.post.repository;
 
 import com.est.cranejob.post.domain.Post;
 import java.util.List;
+
+import com.est.cranejob.user.domain.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
@@ -12,4 +14,5 @@ public interface PostRepository extends JpaRepository<Post, Long> {
 	@Query("select p from Post p where (p.title like %?1% or p.user.nickname like %?1%) and p.isDeleted = false")
 	List<Post> findPostByKeyword(String keyword);
 
+    List<Post> findAllByUser(User user);
 }

--- a/src/main/java/com/est/cranejob/post/service/PostService.java
+++ b/src/main/java/com/est/cranejob/post/service/PostService.java
@@ -118,4 +118,13 @@ public class PostService {
         post.deletedPost();
         postRepository.save(post);
     }
+
+    @Transactional
+    public void deletePostsByUser(User user) {
+        List<Post> posts = postRepository.findAllByUser(user);
+        for (Post post : posts) {
+            post.deletedPost();
+        }
+        postRepository.saveAll(posts); // bulk update
+    }
 }

--- a/src/main/java/com/est/cranejob/user/service/UserService.java
+++ b/src/main/java/com/est/cranejob/user/service/UserService.java
@@ -1,5 +1,6 @@
 package com.est.cranejob.user.service;
 
+import com.est.cranejob.post.service.PostService;
 import com.est.cranejob.user.domain.User;
 import com.est.cranejob.user.dto.request.CreateUserRequest;
 import com.est.cranejob.user.dto.request.UpdateUserRequest;
@@ -16,6 +17,7 @@ import org.springframework.stereotype.Service;
 public class UserService {
 
 	private final UserRepository userRepository;
+	private final PostService postService;
 
 	@Transactional
 	public void createUser(CreateUserRequest createUserRequest) {
@@ -52,5 +54,7 @@ public class UserService {
 		user.deleteUser();
 
 		userRepository.save(user);
+		// 상태가 DELETED로 변경된 경우 해당 사용자의 모든 게시글을 논리 삭제
+		postService.deletePostsByUser(user);
 	}
 }


### PR DESCRIPTION
회원 탈퇴하면 탈퇴한 사용자가 작성한 게시글이 함께 삭제 되도록 수정했습니다.