### PR TITLE
fix: 회원 탈퇴한 사용자의 댓글이 함께 삭제되지 않는 문제 해결

### DIFF
--- a/src/main/java/com/est/cranejob/comment/repository/CommentRepository.java
+++ b/src/main/java/com/est/cranejob/comment/repository/CommentRepository.java
@@ -1,6 +1,7 @@
 package com.est.cranejob.comment.repository;
 
 import com.est.cranejob.comment.domain.Comment;
+import com.est.cranejob.user.domain.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
@@ -8,5 +9,6 @@ import java.util.List;
 
 @Repository
 public interface CommentRepository extends JpaRepository<Comment, Long> {
-    List<Comment> findByPostId(Long postId);
+    List<Comment> findByPostIdAndIsDeletedFalse(Long postId); // 수정된 부분
+    List<Comment> findAllByUser(User user);
 }

--- a/src/main/java/com/est/cranejob/comment/service/CommentService.java
+++ b/src/main/java/com/est/cranejob/comment/service/CommentService.java
@@ -34,7 +34,7 @@ public class CommentService {
     }
 
     public List<Comment> getCommentsByPostId(Long postId) {
-        return commentRepository.findByPostId(postId);
+        return commentRepository.findByPostIdAndIsDeletedFalse(postId);
     }
 
     public Comment getComment(Long commentId) {
@@ -55,7 +55,14 @@ public class CommentService {
                 .orElseThrow(() -> new IllegalArgumentException(commentId + "번 댓글을 찾을 수 없습니다."));
 
         comment.deletedComment();
-        commentRepository.delete(comment);
+        commentRepository.save(comment); // 수정된 부분
     }
 
+    public void deleteCommentByUser(User user){
+        List<Comment> comments = commentRepository.findAllByUser(user);
+        for (Comment comment : comments) {
+            comment.deletedComment();
+        }
+        commentRepository.saveAll(comments); // bulk update
+    }
 }

--- a/src/main/java/com/est/cranejob/post/dto/response/PostUserDetailResponse.java
+++ b/src/main/java/com/est/cranejob/post/dto/response/PostUserDetailResponse.java
@@ -1,11 +1,13 @@
 package com.est.cranejob.post.dto.response;
 
+import com.est.cranejob.comment.domain.Comment;
 import com.est.cranejob.comment.dto.response.CommentResponse;
 import com.est.cranejob.post.domain.Post;
 import lombok.*;
 
 import java.io.Serializable;
 import java.util.List;
+import java.util.stream.Collectors;
 
 /**
  * 게시글의 상세 정보를 일반 사용자가 볼 수 있는 형태로 응답하는 DTO<br>
@@ -24,9 +26,11 @@ public class PostUserDetailResponse implements Serializable {
     private String nickname; // 게시글 작성자
     private String username; // 게시글 작성자 확인
 
-    public static PostUserDetailResponse toDTO(Post post){
-        List<CommentResponse> commentResponseList = post.getComments().stream().map(CommentResponse::toDTO)
-                .toList();
+    public static PostUserDetailResponse toDTO(Post post, List<Comment> comments){
+        List<CommentResponse> commentResponseList = comments.stream()
+                .filter(comment -> !comment.getIsDeleted()) // 수정된 부분
+                .map(CommentResponse::toDTO)
+                .collect(Collectors.toList());
         return PostUserDetailResponse.builder()
                 .id(post.getId())
                 .title(post.getTitle())

--- a/src/main/java/com/est/cranejob/post/service/PostService.java
+++ b/src/main/java/com/est/cranejob/post/service/PostService.java
@@ -2,6 +2,8 @@ package com.est.cranejob.post.service;
 
 import com.est.cranejob.announcement.domain.Announcement;
 import com.est.cranejob.announcement.repository.AnnouncementRepository;
+import com.est.cranejob.comment.domain.Comment;
+import com.est.cranejob.comment.service.CommentService;
 import com.est.cranejob.post.domain.Post;
 import com.est.cranejob.post.dto.request.CreatePostRequest;
 import com.est.cranejob.post.dto.request.UpdatePostRequest;
@@ -33,6 +35,7 @@ public class PostService {
 
     private final PostRepository postRepository;
     private final AnnouncementRepository announcementRepository;
+    private final CommentService commentService;
 
 
     // username(아이디)과 CreatePostRequest에서 작성한 내용을 받아서 Post 엔티티 생성 및 저장
@@ -59,7 +62,8 @@ public class PostService {
         log.debug("Update post details for ID: {}", id);
         Post post = postRepository.findById(id)
                 .orElseThrow(() -> new IllegalArgumentException("게시글을 찾을 수 없습니다." + id));
-        return PostUserDetailResponse.toDTO(post);
+        List<Comment> comments = commentService.getCommentsByPostId(id);
+        return PostUserDetailResponse.toDTO(post, comments);
     }
 
     // 게시글 업데이트 후 저장

--- a/src/main/java/com/est/cranejob/user/service/UserService.java
+++ b/src/main/java/com/est/cranejob/user/service/UserService.java
@@ -1,5 +1,6 @@
 package com.est.cranejob.user.service;
 
+import com.est.cranejob.comment.service.CommentService;
 import com.est.cranejob.post.service.PostService;
 import com.est.cranejob.user.domain.User;
 import com.est.cranejob.user.dto.request.CreateUserRequest;
@@ -18,6 +19,7 @@ public class UserService {
 
 	private final UserRepository userRepository;
 	private final PostService postService;
+	private final CommentService commentService;
 
 	@Transactional
 	public void createUser(CreateUserRequest createUserRequest) {
@@ -56,5 +58,6 @@ public class UserService {
 		userRepository.save(user);
 		// 상태가 DELETED로 변경된 경우 해당 사용자의 모든 게시글을 논리 삭제
 		postService.deletePostsByUser(user);
+		commentService.deleteCommentByUser(user);
 	}
 }


### PR DESCRIPTION
게시글과 마찬가지로 탈퇴한 회원이 작성한 댓글은 is_delete = true 처리하고 해당 댓글을 안보이게 했습니다.